### PR TITLE
Update fastMode

### DIFF
--- a/ntag215.js
+++ b/ntag215.js
@@ -25,6 +25,12 @@ const POWER_OFF_TIME = 5000;
 const ENABLE_LOG = false;
 
 /**
+ * Target console device that is setting when calling {@link fastMode}.
+ * Allowed values: null, "Serial1"
+ */
+const FAST_MODE_CONSOLE = null;
+
+/**
  * The name of the script.
  */
 const FIRMWARE_NAME = "dtm-2.1.0";
@@ -508,8 +514,8 @@ function initialize() {
  * The string indicated by {@link FAST_MODE_STRING} will be sent when {@link fastRx} is ready to start receiving data.
  */
 function fastMode() {
-  // Move the console to Serial1 so it doesn't do anything over Bluetooth.
-  Serial1.setConsole();
+  // Set Bluetooth console so it doesn't do anything over Bluetooth.
+  E.setConsole(FAST_MODE_CONSOLE);
 
   // Attach fastRx to the bluetooth data received event.
   _Bluetooth.on(_Data, fastRx);
@@ -534,6 +540,9 @@ function onFastModeDisconnect() {
 
   // Remove event listener
   NRF.removeListener(_Disconnect, onFastModeDisconnect);
+
+  // Restore Bluetooth console
+  E.setConsole("Bluetooth");
 }
 
 /**
@@ -679,7 +688,7 @@ function fastRx(data) {
           });
 
           _Bluetooth.write(data);
-        }, 0)
+        }, 0);
 
         return;
 

--- a/puck-ntag215-manager/src/espruino.ts
+++ b/puck-ntag215-manager/src/espruino.ts
@@ -73,6 +73,7 @@ export interface SemVer {
 
 export interface GetCodeOptions {
   saveToFlash?: boolean,
+  enableDebug?: boolean,
   board?: string,
   enableLed1?: boolean,
   enableLed2?: boolean,
@@ -142,41 +143,48 @@ export async function checkLed(ledNumber: number): Promise<boolean> {
 export function getCode(options: GetCodeOptions = {}): Promise<string> {
   return new Promise((resolve, reject) => {
     const {
-      saveToFlash = false, board = undefined, enableLed1, enableLed2, enableLed3
+      saveToFlash = false, enableDebug = false, board = undefined, enableLed1, enableLed2, enableLed3
     } = options
     let code = $("#code").text() as string
 
     code = code.replace(
       /(const SAVE_TO_FLASH = )(true|false);/,
-      `$1${saveToFlash};`)
+      `$1${saveToFlash};`
+    ).replace(
+      /(const ENABLE_LOG = )(true|false);/,
+      `$1${enableDebug};`
+    ).replace(
+      /(const FAST_MODE_CONSOLE = )([^;]+);/,
+      `$1${enableDebug ? '"Serial1"' : null};`
+    );
 
-      if (board) {
-        code = code.replace(
-          /(const BOARD = )(process\.env\.BOARD);/,
-          `$1${JSON.stringify(board)};`
-        )
-      }
+    if (board) {
+      code = code.replace(
+        /(const BOARD = )(process\.env\.BOARD);/,
+        `$1${JSON.stringify(board)};`
+      )
+    }
 
-      if (enableLed1 != null) {
-        code = code.replace(
-          /(const ENABLE_LED1 = )(this\.LED1 != null);/,
-          `$1${enableLed1};`
-        )
-      }
+    if (enableLed1 != null) {
+      code = code.replace(
+        /(const ENABLE_LED1 = )(this\.LED1 != null);/,
+        `$1${enableLed1};`
+      )
+    }
 
-      if (enableLed2 != null) {
-        code = code.replace(
-          /(const ENABLE_LED2 = )(this\.LED2 != null);/,
-          `$1${enableLed2};`
-        )
-      }
+    if (enableLed2 != null) {
+      code = code.replace(
+        /(const ENABLE_LED2 = )(this\.LED2 != null);/,
+        `$1${enableLed2};`
+      )
+    }
 
-      if (enableLed3 != null) {
-        code = code.replace(
-          /(const ENABLE_LED3 = )(this\.LED3 != null);/,
-          `$1${enableLed3};`
-        )
-      }
+    if (enableLed3 != null) {
+      code = code.replace(
+        /(const ENABLE_LED3 = )(this\.LED3 != null);/,
+        `$1${enableLed3};`
+      )
+    }
 
     Espruino.callProcessor("transformForEspruino", code, resolve)
   })

--- a/puck-ntag215-manager/src/index.ts
+++ b/puck-ntag215-manager/src/index.ts
@@ -358,6 +358,15 @@ $(() => {
         preventClose: true
       })
 
+      const debugModalResult = await showModal({
+        title: "Enable Debug Mode?",
+        message: modalMessages(ModalMessageType.DebugMode),
+        htmlEscapeBody: false,
+        buttons: ModalButtonTypes.YesNo,
+        dialog: true,
+        preventClose: true
+      })
+
       await showModal({
         title: "Please Wait",
         message: "Uploading script file, please wait.",
@@ -366,6 +375,7 @@ $(() => {
 
       await EspruinoHelper.writeCode({
         saveToFlash: modalResult === ModalResult.ButtonYes,
+        enableDebug: debugModalResult === ModalResult.ButtonYes,
         board,
         enableLed1,
         enableLed2,

--- a/puck-ntag215-manager/src/modalMessages.ts
+++ b/puck-ntag215-manager/src/modalMessages.ts
@@ -2,6 +2,7 @@ const template = require("./templates/modal-messages.pug")
 
 export enum ModalMessageType {
   SaveToFlash = "save-to-flash",
+  DebugMode = "debug-mode",
   DfuInstructions = "dfu-instructions",
   FirmwareUpdate = "firmware-update"
 }

--- a/puck-ntag215-manager/src/puck.ts
+++ b/puck-ntag215-manager/src/puck.ts
@@ -141,14 +141,13 @@ export class Puck {
 
   private initFastMode(timeout: number = 0): Promise<void> {
     return new Promise(async (resolve, reject) => {
-      const instance = this
       var errorTimer: NodeJS.Timeout = undefined
 
-      function finishName(this: BluetoothRemoteGATTCharacteristic, ev: CharacteristicEvent) {
+      function finishName(ev: CharacteristicEvent) {
         var text = new TextDecoder().decode(ev.target.value)
 
-        if (text == "DTM_PUCK_FAST") {
-          this.removeEventListener("characteristicvaluechanged", finishName)
+        if (text.includes("DTM_PUCK_FAST")) {
+          ev.target.removeEventListener("characteristicvaluechanged", finishName)
 
           if (errorTimer) {
             clearTimeout(errorTimer)

--- a/puck-ntag215-manager/src/templates/modal-messages.pug
+++ b/puck-ntag215-manager/src/templates/modal-messages.pug
@@ -4,6 +4,10 @@ case kind
     p If this feature is not enabled, the tags stored on the puck will be lost when the battery dies or if it is removed.
     p This may reduce the life of the puck due to the additional writes to the flash storage.
 
+  when "debug-mode"
+    p Do you want to enable debug mode?
+    p This will enable log output and use "Serial1" as a console when fast mode is enabled.
+
   when "dfu-instructions"
     p To enter DFU mode, please remove the battery from your Puck.js and re-insert it while holding the power button until the LED indicator turns green.
 


### PR DESCRIPTION
Hi! 👋 

Thank you for your work!

I've just received Puck.js and tried to use your firmware & script but cannot, as always stuck on the "Connecting" modal.
After debugging, I found that the front end looks extracted for the `DTM_PUCK_FAST` string. It did not occur in a raw state; the string always contained some garbage and the error `ERROR: Invalid RX or TX pins`.

So this PR doesn't use the serial as a console but disables it completely.
And with an increased timeout, I can receive the necessary string and use the application.